### PR TITLE
Feat/multi control

### DIFF
--- a/src/multi_control/Makefile
+++ b/src/multi_control/Makefile
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+OUTPUT := .output
+CLANG ?= clang
+LLVM_STRIP ?= llvm-strip
+LIBBPF_SRC := $(abspath ../../libbpf/src)
+BPFTOOL_SRC := $(abspath ../../bpftool/src)
+LIBBPF_OBJ := $(abspath $(OUTPUT)/libbpf.a)
+BPFTOOL_OUTPUT ?= $(abspath $(OUTPUT)/bpftool)
+BPFTOOL ?= $(BPFTOOL_OUTPUT)/bootstrap/bpftool
+ARCH ?= $(shell uname -m | sed 's/x86_64/x86/' \
+			 | sed 's/aarch64/arm64/' \
+			 | sed 's/ppc64le/powerpc/' \
+			 | sed 's/mips.*/mips/' \
+			 | sed 's/arm.*/arm/' \
+			 | sed 's/riscv64/riscv/')
+VMLINUX := ../../vmlinux/$(ARCH)/vmlinux.h
+# Use our own libbpf API headers and Linux UAPI headers distributed with
+# libbpf to avoid dependency on system-wide headers, which could be missing or
+# outdated
+INCLUDES := -I$(OUTPUT) -I../../libbpf/include/uapi -I$(dir $(VMLINUX))
+CFLAGS := -g -Wall
+ALL_LDFLAGS := $(LDFLAGS) $(EXTRA_LDFLAGS)
+
+APPS = multi_control
+
+# Get Clang's default includes on this system. We'll explicitly add these dirs
+# to the includes list when compiling with `-target bpf` because otherwise some
+# architecture-specific dirs will be "missing" on some architectures/distros -
+# headers such as asm/types.h, asm/byteorder.h, asm/socket.h, asm/sockios.h,
+# sys/cdefs.h etc. might be missing.
+#
+# Use '-idirafter': Don't interfere with include mechanics except where the
+# build would have failed anyways.
+CLANG_BPF_SYS_INCLUDES = $(shell $(CLANG) -v -E - </dev/null 2>&1 \
+	| sed -n '/<...> search starts here:/,/End of search list./{ s| \(/.*\)|-idirafter \1|p }')
+
+ifeq ($(V),1)
+	Q =
+	msg =
+else
+	Q = @
+	msg = @printf '  %-8s %s%s\n'					\
+		      "$(1)"						\
+		      "$(patsubst $(abspath $(OUTPUT))/%,%,$(2))"	\
+		      "$(if $(3), $(3))";
+	MAKEFLAGS += --no-print-directory
+endif
+
+define allow-override
+  $(if $(or $(findstring environment,$(origin $(1))),\
+            $(findstring command line,$(origin $(1)))),,\
+    $(eval $(1) = $(2)))
+endef
+
+$(call allow-override,CC,$(CROSS_COMPILE)cc)
+$(call allow-override,LD,$(CROSS_COMPILE)ld)
+
+.PHONY: all
+all: $(APPS)
+
+.PHONY: clean
+clean:
+	$(call msg,CLEAN)
+	$(Q)rm -rf $(OUTPUT) $(APPS)
+
+$(OUTPUT) $(OUTPUT)/libbpf $(BPFTOOL_OUTPUT):
+	$(call msg,MKDIR,$@)
+	$(Q)mkdir -p $@
+
+# Build libbpf
+$(LIBBPF_OBJ): $(wildcard $(LIBBPF_SRC)/*.[ch] $(LIBBPF_SRC)/Makefile) | $(OUTPUT)/libbpf
+	$(call msg,LIB,$@)
+	$(Q)$(MAKE) -C $(LIBBPF_SRC) BUILD_STATIC_ONLY=1		      \
+		    OBJDIR=$(dir $@)/libbpf DESTDIR=$(dir $@)		      \
+		    INCLUDEDIR= LIBDIR= UAPIDIR=			      \
+		    install
+
+# Build bpftool
+$(BPFTOOL): | $(BPFTOOL_OUTPUT)
+	$(call msg,BPFTOOL,$@)
+	$(Q)$(MAKE) ARCH= CROSS_COMPILE= OUTPUT=$(BPFTOOL_OUTPUT)/ -C $(BPFTOOL_SRC) bootstrap
+
+# Build BPF code
+$(OUTPUT)/%.bpf.o: %.bpf.c $(LIBBPF_OBJ) $(wildcard %.h) $(VMLINUX) | $(OUTPUT)
+	$(call msg,BPF,$@)
+	$(Q)$(CLANG) -g -fstack-protector -O2 -target bpf -D__TARGET_ARCH_$(ARCH) $(INCLUDES) $(CLANG_BPF_SYS_INCLUDES) -c $(filter %.c,$^) -o $@
+	$(Q)$(LLVM_STRIP) -g $@ # strip useless DWARF info
+
+# Generate BPF skeletons
+$(OUTPUT)/%.skel.h: $(OUTPUT)/%.bpf.o | $(OUTPUT) $(BPFTOOL)
+	$(call msg,GEN-SKEL,$@)
+	$(Q)$(BPFTOOL) gen skeleton $< > $@
+
+# Build user-space code
+$(patsubst %,$(OUTPUT)/%.o,$(APPS)): %.o: %.skel.h
+
+$(OUTPUT)/%.o: %.c $(wildcard %.h) | $(OUTPUT)
+	$(call msg,CC,$@)
+	$(Q)$(CC) $(CFLAGS) $(INCLUDES) -c $(filter %.c,$^) -o $@
+
+# Build application binary
+$(APPS): %: $(OUTPUT)/%.o $(LIBBPF_OBJ) | $(OUTPUT)
+	$(call msg,BINARY,$@)
+	$(Q)$(CC) $(CFLAGS) $^ $(ALL_LDFLAGS) -lelf -lz -o $@
+
+# delete failed targets
+.DELETE_ON_ERROR:
+
+# keep intermediate (.skel.h, .bpf.o, etc) targets
+.SECONDARY:

--- a/src/multi_control/Makefile
+++ b/src/multi_control/Makefile
@@ -83,7 +83,7 @@ $(BPFTOOL): | $(BPFTOOL_OUTPUT)
 # Build BPF code
 $(OUTPUT)/%.bpf.o: %.bpf.c $(LIBBPF_OBJ) $(wildcard %.h) $(VMLINUX) | $(OUTPUT)
 	$(call msg,BPF,$@)
-	$(Q)$(CLANG) -g -fstack-protector -O2 -target bpf -D__TARGET_ARCH_$(ARCH) $(INCLUDES) $(CLANG_BPF_SYS_INCLUDES) -c $(filter %.c,$^) -o $@
+	$(Q)$(CLANG) -g -fno-stack-protector -O2 -target bpf -D__TARGET_ARCH_$(ARCH) $(INCLUDES) $(CLANG_BPF_SYS_INCLUDES) -c $(filter %.c,$^) -o $@
 	$(Q)$(LLVM_STRIP) -g $@ # strip useless DWARF info
 
 # Generate BPF skeletons

--- a/src/multi_control/multi_control.bpf.c
+++ b/src/multi_control/multi_control.bpf.c
@@ -1,0 +1,101 @@
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+
+#define AF_INET 2
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, __u32);   // ns_id
+    __type(value, __u32);
+    __uint(max_entries, 10240);
+} ns_id_map SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, struct syscall_key);
+    __type(value, struct syscall_policy);
+    __uint(max_entries, 10240);
+} syscall_policy_map SEC(".maps");
+
+struct syscall_key {
+    __u32 ns_id;
+    __u32 event_id;
+};
+
+struct syscall_policy {
+    __u32 action;
+    char argument[256];
+};
+
+char LICENSE[] SEC("license") = "GPL";
+
+SEC("lsm/task_fix_setuid")
+int BPF_PROG(prevent_root_setuid, struct cred *new, const struct cred *old, int flags) {
+    __u32 ns_id, pid;
+    __u32 new_uid, old_uid;
+
+    struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+    ns_id = BPF_CORE_READ(task, nsproxy, pid_ns_for_children, ns.inum);
+
+    pid = bpf_get_current_pid_tgid() >> 32;
+    bpf_core_read(&new_uid, sizeof(new_uid), &new->uid.val);
+    bpf_core_read(&old_uid, sizeof(old_uid), &old->uid.val);
+
+    __u32 *watched = bpf_map_lookup_elem(&ns_id_map, &ns_id);
+
+    bpf_printk("lsm/task_fix_setuid for ns_id %u, pid %u, new uid: %u, old uid: %u", ns_id, pid, new_uid, old_uid);
+
+    if (watched && new_uid == 0) {
+        bpf_printk("Prevented root escalation for watched ns_id %u", ns_id);
+        return -1;
+    }
+
+    return 0;
+}
+
+SEC("lsm/socket_connect")
+int BPF_PROG(prevent_socket_connect, struct socket *sock, struct sockaddr *address, int addrlen) {
+    __u32 ns_id, pid;
+    struct syscall_key key = {0};
+    struct syscall_policy *policy;
+
+    struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+    ns_id = BPF_CORE_READ(task, nsproxy, pid_ns_for_children, ns.inum);
+
+    pid = bpf_get_current_pid_tgid() >> 32;
+
+    key.ns_id = ns_id;
+    key.event_id = 1;
+
+    policy = bpf_map_lookup_elem(&syscall_policy_map, &key);
+    if (policy) {
+        if (address->sa_family == AF_INET) {
+            struct sockaddr_in *addr = (struct sockaddr_in *)address;
+            __be32 dst_ip;
+            __be16 dst_port;
+
+            bpf_probe_read(&dst_ip, sizeof(dst_ip), &addr->sin_addr.s_addr);
+            bpf_probe_read(&dst_port, sizeof(dst_port), &addr->sin_port);
+
+            __be32 blocked_ip;
+            bpf_probe_read(&blocked_ip, sizeof(blocked_ip), policy->argument);
+            if (policy->action == 1) {
+                if (dst_ip == blocked_ip) {
+                    bpf_printk("Connection blocked to IP: %pI4 for ns_id %u\n", &dst_ip, ns_id);
+                    return -1;
+                }
+                return 0;
+            }else if (policy->action == 0) {
+                if (dst_ip == blocked_ip) {
+                    bpf_printk("Connection allowed to IP: %pI4 for ns_id %u\n", &dst_ip, ns_id);
+                    return 0;
+                }
+                return -1;
+            }
+        }
+    }
+
+    return 0;
+}

--- a/src/multi_control/multi_control.bpf.c
+++ b/src/multi_control/multi_control.bpf.c
@@ -14,19 +14,19 @@ struct {
 
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
-    __type(key, struct syscall_key);
-    __type(value, struct syscall_policy);
+    __type(key, struct event_key);
+    __type(value, struct event_policy);
     __uint(max_entries, 10240);
-} syscall_policy_map SEC(".maps");
+} event_policy_map SEC(".maps");
 
-struct syscall_key {
+struct event_key {
     __u32 ns_id;
     __u32 event_id;
+    char argument[256];
 };
 
-struct syscall_policy {
+struct event_policy {
     __u32 action;
-    char argument[256];
 };
 
 char LICENSE[] SEC("license") = "GPL";
@@ -58,44 +58,42 @@ int BPF_PROG(prevent_root_setuid, struct cred *new, const struct cred *old, int 
 SEC("lsm/socket_connect")
 int BPF_PROG(prevent_socket_connect, struct socket *sock, struct sockaddr *address, int addrlen) {
     __u32 ns_id, pid;
-    struct syscall_key key = {0};
-    struct syscall_policy *policy;
+    struct event_key key = {0};
+    struct event_policy *policy;
 
     struct task_struct *task = (struct task_struct *)bpf_get_current_task();
     ns_id = BPF_CORE_READ(task, nsproxy, pid_ns_for_children, ns.inum);
 
     pid = bpf_get_current_pid_tgid() >> 32;
 
-    key.ns_id = ns_id;
-    key.event_id = 1;
+    if (address->sa_family == AF_INET) {
+        struct sockaddr_in *addr = (struct sockaddr_in *)address;
+        __be32 dst_ip;
+        __be16 dst_port;
 
-    policy = bpf_map_lookup_elem(&syscall_policy_map, &key);
-    if (policy) {
-        if (address->sa_family == AF_INET) {
-            struct sockaddr_in *addr = (struct sockaddr_in *)address;
-            __be32 dst_ip;
-            __be16 dst_port;
+        bpf_probe_read(&dst_ip, sizeof(dst_ip), &addr->sin_addr.s_addr);
+        bpf_probe_read(&dst_port, sizeof(dst_port), &addr->sin_port);
 
-            bpf_probe_read(&dst_ip, sizeof(dst_ip), &addr->sin_addr.s_addr);
-            bpf_probe_read(&dst_port, sizeof(dst_port), &addr->sin_port);
+        key.ns_id = ns_id;
+        key.event_id = 1;
+        bpf_probe_read(&key.argument, sizeof(__be32), &dst_ip);
 
-            __be32 blocked_ip;
-            bpf_probe_read(&blocked_ip, sizeof(blocked_ip), policy->argument);
-            if (policy->action == 1) {
-                if (dst_ip == blocked_ip) {
-                    bpf_printk("Connection blocked to IP: %pI4 for ns_id %u\n", &dst_ip, ns_id);
-                    return -1;
-                }
+        policy = bpf_map_lookup_elem(&event_policy_map, &key);
+        if (policy) {
+            if (policy->action == 0) {  // Allow
+                bpf_printk("Connection allowed to IP: %pI4 for ns_id %u\n", &dst_ip, ns_id);
                 return 0;
-            }else if (policy->action == 0) {
-                if (dst_ip == blocked_ip) {
-                    bpf_printk("Connection allowed to IP: %pI4 for ns_id %u\n", &dst_ip, ns_id);
-                    return 0;
-                }
+            } else if (policy->action == 1) {  // Block
+                bpf_printk("Connection blocked to IP: %pI4 for ns_id %u\n", &dst_ip, ns_id);
                 return -1;
             }
+        } else {
+            // 정책이 없는 경우 허용
+            bpf_printk("No policy found for IP: %pI4 in ns_id %u, allowing connection\n", &dst_ip, ns_id);
+            return 0;
         }
     }
 
+    // IPv4가 아닌 경우 기본적으로 허용
     return 0;
 }

--- a/src/multi_control/multi_control.bpf.c
+++ b/src/multi_control/multi_control.bpf.c
@@ -33,9 +33,9 @@ static __always_inline __u64 get_cgroup_id() {
         return 0;
     }
 
-    int cgrp_id = memory_cgrp_id;
+    int mem_cgrp_id = memory_cgrp_id;
 
-    __u64 cgroup_id = BPF_CORE_READ(cur_tsk, cgroups, subsys[cgrp_id], cgroup, kn, id);
+    __u64 cgroup_id = BPF_CORE_READ(cur_tsk, cgroups, subsys[mem_cgrp_id], cgroup, kn, id);
     bpf_printk("cgroup_id: %llu\n", cgroup_id);
 
     return cgroup_id;

--- a/src/multi_control/multi_control.c
+++ b/src/multi_control/multi_control.c
@@ -1,0 +1,169 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <signal.h>
+#include <string.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <linux/types.h>
+#include <bpf/libbpf.h>
+#include "multi_control.skel.h"
+
+#define MAX_PATH 256
+
+struct syscall_key {
+    __u32 ns_id;
+    __u32 event_id;
+};
+
+struct syscall_policy {
+    __u32 action;
+    char argument[256];
+};
+
+int get_namespace_id(int container_pid) {
+    
+    // PID 네임스페이스 ID 찾기
+    char path[MAX_PATH];
+    snprintf(path, sizeof(path), "/proc/%d/ns/pid", container_pid);
+    
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        perror("Failed to open namespace file");
+        return 1;
+    }
+
+    char link_target[MAX_PATH];
+    ssize_t len = readlink(path, link_target, sizeof(link_target)-1);
+    if (len < 0) {
+        perror("Failed to read link");
+        close(fd);
+        return 1;
+    }
+    link_target[len] = '\0';
+
+    unsigned int ns_id;
+    if (sscanf(link_target, "pid:[%u]", &ns_id) != 1) {
+        fprintf(stderr, "Failed to parse namespace ID\n");
+        close(fd);
+        return 1;
+    }
+
+    printf("PID namespace ID for PID %d: %u\n", container_pid, ns_id);
+
+    close(fd);
+    return ns_id;
+}
+
+int main(int argc, char **argv) {
+    struct multi_control_bpf *skel;
+    int err;
+
+    skel = multi_control_bpf__open(); // Ensure this function name matches
+    if (!skel) {
+        fprintf(stderr, "Failed to open and load BPF skeleton\n");
+        return 1;
+    }
+
+    // Load & verify BPF programs
+    err = multi_control_bpf__load(skel); // Ensure this function name matches
+    if (err) {
+        fprintf(stderr, "Failed to load and verify BPF skeleton\n");
+        goto cleanup;
+    }
+
+    err = multi_control_bpf__attach(skel);
+    if (err) {
+        fprintf(stderr, "Failed to attach BPF skeleton\n");
+        goto cleanup;
+    }
+
+    // main loop process from user's input
+    while (1) {
+        char pid_str[256];
+        char event_str[256];
+        char ip_str[16];
+        char action_str[10];
+        __u32 pid;
+        __u32 value;    // 무의미한 값
+        __u32 ns_id;
+        __u32 event_id;
+        __u32 action;
+
+        printf("Enter pid name to restrict (or 'quit' to exit): ");
+        if (fgets(pid_str, sizeof(pid_str), stdin) == NULL) {
+            break;
+        }
+        pid_str[strcspn(pid_str, "\n")] = 0;
+
+        // quit program
+        if (strcmp(pid_str, "quit") == 0) {
+            break;
+        }
+
+        pid = (__u32)atoi(pid_str);
+        ns_id = get_namespace_id(pid);
+        
+        printf("Enter event (e.g., task_fix_setuid, socket_connect): ");
+        if (fgets(event_str, sizeof(event_str), stdin) == NULL) {
+            break;
+        }
+        event_str[strcspn(event_str, "\n")] = 0;
+
+        if (strcmp(event_str, "task_fix_setuid") == 0) {
+            event_id = 0;
+            err = bpf_map__update_elem(skel->maps.ns_id_map, &ns_id, sizeof(ns_id), &value, sizeof(value), BPF_ANY);
+            if (err) {
+                fprintf(stderr, "Failed to update map: %d\n", err);
+                continue;
+            }
+
+            printf("Now restricting root access in pid: %s\n", pid_str);
+        } else if (strcmp(event_str, "socket_connect") == 0) {
+            event_id = 1;
+            printf("Enter IP to block or allow (e.g., 8.8.8.8): ");
+            if (fgets(ip_str, sizeof(ip_str), stdin) == NULL) {
+                break;
+            }
+            ip_str[strcspn(ip_str, "\n")] = 0;
+
+            struct in_addr ip_addr;
+            if (inet_pton(AF_INET, ip_str, &ip_addr) != 1) {
+                fprintf(stderr, "ERROR: Invalid IP address\n");
+                continue;
+            }
+
+            printf("Enter action to block or allow (e.g., block, allow): ");
+            if (fgets(action_str, sizeof(action_str), stdin) == NULL) {
+                break;
+            }
+            action_str[strcspn(action_str, "\n")] = 0;
+
+            if (strcmp(action_str, "allow") == 0) action = 0;
+            if (strcmp(action_str, "block") == 0) action = 1;
+
+            struct syscall_key key = {
+                .ns_id = ns_id,
+                .event_id = event_id
+            };
+
+            struct syscall_policy policy = {
+                .action = action
+            };
+            memcpy(policy.argument, &ip_addr.s_addr, sizeof(ip_addr.s_addr));
+
+            err = bpf_map__update_elem(skel->maps.syscall_policy_map, &key, sizeof(key), &policy, sizeof(policy), BPF_ANY);
+            if (err) {
+                fprintf(stderr, "Failed to update map: %d\n", err);
+                continue;
+            }
+
+            printf("Now restricting ip/port(%s) access in pid: %s\n", ip_str, pid_str);
+        }
+    }
+
+cleanup:
+    multi_control_bpf__destroy(skel);
+    return err != 0;
+}

--- a/src/multi_control/multi_control.c
+++ b/src/multi_control/multi_control.c
@@ -12,14 +12,14 @@
 
 #define MAX_PATH 256
 
-struct syscall_key {
+struct event_key {
     __u32 ns_id;
     __u32 event_id;
+    char argument[256];
 };
 
-struct syscall_policy {
+struct event_policy {
     __u32 action;
-    char argument[256];
 };
 
 int get_namespace_id(int container_pid) {
@@ -143,17 +143,17 @@ int main(int argc, char **argv) {
             if (strcmp(action_str, "allow") == 0) action = 0;
             if (strcmp(action_str, "block") == 0) action = 1;
 
-            struct syscall_key key = {
+            struct event_key key = {
                 .ns_id = ns_id,
                 .event_id = event_id
             };
+            memcpy(key.argument, &ip_addr.s_addr, sizeof(ip_addr.s_addr));
 
-            struct syscall_policy policy = {
+            struct event_policy policy = {
                 .action = action
             };
-            memcpy(policy.argument, &ip_addr.s_addr, sizeof(ip_addr.s_addr));
 
-            err = bpf_map__update_elem(skel->maps.syscall_policy_map, &key, sizeof(key), &policy, sizeof(policy), BPF_ANY);
+            err = bpf_map__update_elem(skel->maps.event_policy_map, &key, sizeof(key), &policy, sizeof(policy), BPF_ANY);
             if (err) {
                 fprintf(stderr, "Failed to update map: %d\n", err);
                 continue;


### PR DESCRIPTION
### multi_control.bpf.c
1. event_mode_map
    - event_id: decides which event to hook.
    - event_mode: decides whether to block or allow.
2. event_policy_map
    - ns_id: decides which container is under control.
    - event_id: decides which event to hook.
    - argument: decides path, IP, port, etc.

You can use cgroup_id to identify the container, but cgroup_id changes when the container restarts.

### multi_control.c
1. Choose the runtime that will be under control.
2. Choose the event to hook.
3. If needed, enter the argument.
4. Choose the action: block or allow.
5. If action conflicts, the latest action will be chosen, and the old policy will be deleted.